### PR TITLE
Reduce Docker image size, improve image efficiency, update docker README.md

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:latest
-RUN  apt-get update \
-  && apt-get install -y wget \
-  && rm -rf /var/lib/apt/lists/*
-RUN wget -O /usr/bin/findomain https://github.com/Edu4rdSHL/findomain/releases/latest/download/findomain-linux
-RUN chmod +x /usr/bin/findomain
-RUN  apt-get remove --autoremove -y wget
+# docker run -it findomain -t example.com
+FROM alpine:latest
+LABEL maintainer="wfnintr@null.net"
+WORKDIR /opt/findomain
+RUN wget -qO /usr/bin/findomain https://github.com/Edu4rdSHL/findomain/releases/latest/download/findomain-linux && \
+	chmod +x /usr/bin/findomain
+ENTRYPOINT ["findomain"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,13 +1,34 @@
-# How to execute a findomain in a docker container
+## Basic Usage
+```
+docker run -it findomain -t example.com
+```
 
-1. Build and tag the image.
+Configuration Notes:
+- Pass your config to the container by bind mounting to `/opt/findomain` with the flag `-v`,   
+ie. `-v $(pwd):/opt/findomain`
+- Results saved with `-o` will be saved to `/opt/findomain` inside the container and consequently through the bind mount to your local host. This way the results will persist on your machine even if the container is only temporary.
 
-``$ docker build -f Dockerfile . -t findomain``
 
-2. Run the image.
+## Full Example
+```
+docker run --rm -it -v $(pwd):/opt/findomain findomain -c config.toml -t example.com
+```
 
-``$ docker run -it findomain /bin/bash``
+---
 
-3. Execute
+#### Building the image yourself
+1. Clone the repo
+```
+git clone https://github.com/Findomain/Findomain
+```
 
-``$ findomain``
+2. Build the image
+```
+cd Findomain/docker
+docker build . -t findomain
+```
+
+3. Run it as usual
+```
+docker run -it findomain
+```


### PR DESCRIPTION
Changes:
- Changed the base image and reduced image layers
- Was 114MB and 7 layers (based on `ubuntu:latest`)
- Now 22MB, only 3 layers, 100% efficiency (based on `alpine:latest`)
- `WORKDIR` is set to `/opt/findomain`
- Your config can be passed by bind mounting to `/opt/findomain` with the flag `-v`
- Results saved with `-o` will be saved to `/opt/findomain` inside the container and consequently through the bind mount to your local host. This way the results will persist on your machine even if the container is only temporary.
