### PR TITLE
Enable gzip compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "async-compression"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72c1f1154e234325b50864a349b9c8e56939e266a4c307c0f159812df2f9537"
+dependencies = [
+ "bytes 0.5.6",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite 0.2.0",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +234,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
+name = "crc32fast"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +380,18 @@ dependencies = [
  "serde_derive",
  "trust-dns-resolver",
  "url",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1377,6 +1411,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb15d6255c792356a0f578d8a645c677904dc02e862bebe2ecc18e0c01b9a0ce"
 dependencies = [
+ "async-compression",
  "base64 0.13.0",
  "bytes 0.5.6",
  "encoding_rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 [dependencies]
 serde = { version = "1.0.118", features = ["derive"] }
 serde_derive = "1.0.118"
-reqwest = { version = "0.10.9", features = ["blocking", "json"] }
+reqwest = { version = "0.10.9", features = ["blocking", "json", "gzip"] }
 trust-dns-resolver = { version = "0.19.6", features = ["dns-over-rustls"] }
 clap = { version = "2.33.3", features = ["yaml"] }
 lazy_static = "1.4.0"


### PR DESCRIPTION
I'm reading `reqwest` docs for a personal project and noticed this part: https://docs.rs/reqwest/0.11.0/reqwest/struct.ClientBuilder.html#method.gzip

Enabling the `gzip` feature adds a `accept-encoding: gzip` header to all requests and automatically handles the decompression. Given the type of data that Findomain handles this should help with performance and bandwidth.

Just to make sure I ran

```rust
use reqwest::Client;

#[tokio::main]
async fn main() {
    let client = Client::builder().build().unwrap();
    client.get("http://localhost:1234").send().await;
}
```
with

```toml
reqwest = { version = "0.11", features = ["gzip"] }
```

and

```toml
reqwest = { version = "0.11", features = [] }
```

and could confirm with my `nc` listener that the header was indeed missing by default without the feature.