### PR TITLE
Add -all flag to subfinder for more results: Fix #185

### DIFF
--- a/src/external_subs.rs
+++ b/src/external_subs.rs
@@ -66,7 +66,7 @@ pub fn get_subfinder_subdomains(
     let mut subdomains = HashSet::new();
     if !(File::create(output_filename).is_ok()
         && Command::new("subfinder")
-            .args(&mut vec!["-silent", "-d", target, "-o", output_filename])
+            .args(&mut vec!["-silent","-all", "-d", target, "-o", output_filename])
             .output()
             .is_ok()
         && files::check_no_empty(output_filename))


### PR DESCRIPTION
Attention, this change will make Findomain slower when subfinder is used. Because more sources will be queried.

#185