### PR TITLE
add docker workflow to build multi-platform image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,31 @@
+name: Build Docker images
+
+on:
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_NAME: findomain
+      IMAGE_TAG: latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}


### PR DESCRIPTION
Add now workflow to build and push a multi-platform Docker image for following platforms:
- linux/amd64
- linux/arm64

Tested on macOS with Intel and Apple Silicon CPU.

In order to push the image, make sure that you set two workflow secrets for the project:
- `DOCKERHUB_USERNAME` - your Docker username
- `DOCKERHUB_TOKEN` - a personal access  token that can be issued at https://hub.docker.com/settings/security